### PR TITLE
Allow identifiers as keys in maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.swp
 *.*~
+**/.idea

--- a/aeon/src/object.rs
+++ b/aeon/src/object.rs
@@ -79,15 +79,14 @@ impl AeonObject {
 
     pub fn apply_macro(&mut self, name: String, mut params: Vec<AeonValue>) -> AeonValue {
         if let Some(mac) = self.macros.get(name.as_str()) {
-            let len = params.len();
-            if mac.len() != len {
-                panic!(format!("Wrong number of args to macro {}: was {}, expected {}", name, len, mac.len()));
+            if mac.len() != params.len() {
+                panic!(format!("Wrong number of args to macro {}: was {}, expected {}", name, params.len(), mac.len()));
             }
 
             let mut map = HashMap::<String,AeonValue>::new();
-            let mut drained = params.drain(..);
-            for p in 0..len{
-                mac.apply(p, drained.next().unwrap(), &mut map);
+
+            for (idx,parameter) in params.drain(..).enumerate() {
+                mac.apply(idx, parameter, &mut map);
             }
             AeonValue::Map(map)
         } else {

--- a/aeon/src/value.rs
+++ b/aeon/src/value.rs
@@ -10,4 +10,3 @@ pub enum AeonValue {
     Map(HashMap<String,AeonValue>),
     List(Vec<AeonValue>),
 }
-

--- a/aeon/tests/deserializer.rs
+++ b/aeon/tests/deserializer.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod tests {
+    use aeon::convert::{AeonObjectConvert, AeonConvert};
+    use aeon::value::AeonValue;
+
+    #[test]
+    pub fn deserialize_map_with_both_quoted_and_not_quoted_keys() {
+        let mut aeon = r#"map: {test: 1, "two": 2}"#.into();
+        let ser = aeon::deserialize(aeon).expect("failed to deserialize");
+
+        assert_eq!(ser.get_path("map/test").int(), Some(1));
+        assert_eq!(ser.get_path("map/two").int(), Some(2));
+    }
+}

--- a/aeon/tests/serializer.rs
+++ b/aeon/tests/serializer.rs
@@ -95,10 +95,26 @@ mod tests {
         // or just don't test the entire serialization and instead its parts
         assert!(serialized.starts_with("character: {"));
         assert!(serialized.ends_with("}\n\n"));
-        assert!(serialized.contains(r#""name": "erki""#));
-        assert!(serialized.contains(r#""world": 1"#));
-        assert!(serialized.contains(r#""double": 139.3567"#));
-        assert!(serialized.contains(r#""or_nothing": nil"#));
+        assert!(serialized.contains(r#"name: "erki""#));
+        assert!(serialized.contains("world: 1"));
+        assert!(serialized.contains("double: 139.3567"));
+        assert!(serialized.contains("or_nothing: nil"));
+        assert!(serialized.contains(","));
+    }
+
+    #[test]
+    pub fn serialize_map_property_key_that_is_not_a_valid_identifier() {
+        let mut aeon = AeonObject::new();
+        let aeon_value = AeonProperty::new("job".into(), AeonValue::Map(map![
+           "9to5".into() => AeonValue::Bool(true),
+           "NineToFive".into() => AeonValue::Bool(true),
+        ]));
+        aeon.add_property(aeon_value);
+        let serialized = aeon::serialize(aeon);
+        assert!(serialized.starts_with("job: {"));
+        assert!(serialized.ends_with("}\n\n"));
+        assert!(serialized.contains(r#""9to5": true"#));
+        assert!(serialized.contains(r#"NineToFive: true"#));
         assert!(serialized.contains(","));
     }
 


### PR DESCRIPTION
This adds identifiers as valid keys in map entries, e.g. this is now a valid property:
```
map:  {key: 1}
```